### PR TITLE
support alternative readme filenames

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,8 @@ module.exports = getPackageReadme
 var get = require('simple-get')
 var gh = require('github-url-to-object')
 
-var NPM_REGISTRY = 'https://registry.npmjs.org/%s/latest'
-var GITHUB_README = 'https://raw.githubusercontent.com/%s/master/README.md'
+var NPM_REGISTRY = 'https://registry.npmjs.org/%s'
+var GITHUB_README = 'https://raw.githubusercontent.com/%s'
 
 function getPackageReadme (pkgName, cb) {
   var npmUrl = NPM_REGISTRY.replace('%s', pkgName)
@@ -15,6 +15,9 @@ function getPackageReadme (pkgName, cb) {
     } catch (err) {
       return cb(new Error(pkgName + ': cannot parse registry data: ' + err.message))
     }
+    var readmeFilename = data.readmeFilename
+    if (!readmeFilename) return cb(new Error(pkgName + ': package.json has no readmeFilename'))
+
     var repoUrl = data.repository && data.repository.url
     if (!repoUrl) return cb(new Error(pkgName + ': package.json has no repository'))
 
@@ -23,7 +26,8 @@ function getPackageReadme (pkgName, cb) {
     var repo = repoObj && repoObj.repo
     if (!user || !repo) return cb(new Error(pkgName + ': cannot parse repository url'))
 
-    var githubUrl = GITHUB_README.replace('%s', user + '/' + repo)
+    var readmePath = user + '/' + repo + '/master/' + readmeFilename
+    var githubUrl = GITHUB_README.replace('%s', readmePath)
 
     get.concat(githubUrl, function (err, data) {
       if (err) return cb(err)

--- a/test/basic.js
+++ b/test/basic.js
@@ -11,6 +11,14 @@ test('get package readme for "webtorrent"', function (t) {
   })
 })
 
+test('get package readme for "browserify"', function (t) {
+  t.plan(2)
+  getPackageReadme('browserify', function (err, readme) {
+    t.ok(/browserify/i.test(readme))
+    t.ok(/modules/i.test(readme))
+  })
+})
+
 test('get error for invalid package name', function (t) {
   t.plan(1)
   getPackageReadme('invalid-package-name-92342384', function (err, readme) {


### PR DESCRIPTION
This PR adds support for alternative readme filenames such as `readme.markdown` which [Browserify](https://github.com/substack/node-browserify) and some other packages use.

This looks into the `package.json` for the `readmeFilename` field, which npm [chooses not to document](https://github.com/npm/npm/issues/3573) but seems to exist when a readme is properly included in the package.

Unfortunately this field does not seem to be included in the reponse from URLs like https://registry.npmjs.org/get-package-readme/latest but does for URLs like https://registry.npmjs.org/get-package-readme
