### PR TITLE
Use `readme` from the NPM API response if present

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ getPackageReadme('webtorrent', function (err, readme) {
 ## why this instead of [`readme-getter`](https://www.npmjs.com/package/readme-getter)?
 
 `get-package-readme` (this package) gets an npm packages' GitHub readme (from the `master`
-branch). If you want the npm readme, you should use `readme-getter`.
+branch) and falls back to the npm readme if it exists. If you want just the npm readme, you should use `readme-getter`.
 
 ## license
 

--- a/index.js
+++ b/index.js
@@ -15,22 +15,30 @@ function getPackageReadme (pkgName, cb) {
     } catch (err) {
       return cb(new Error(pkgName + ': cannot parse registry data: ' + err.message))
     }
+
+    var checkFallback = function (err) {
+      if (data.readme) {
+        return cb(null, data.readme)
+      }
+      return cb(err)
+    }
+
     var readmeFilename = data.readmeFilename
-    if (!readmeFilename) return cb(new Error(pkgName + ': package.json has no readmeFilename'))
+    if (!readmeFilename) return checkFallback(new Error(pkgName + ': package.json has no readmeFilename'))
 
     var repoUrl = data.repository && data.repository.url
-    if (!repoUrl) return cb(new Error(pkgName + ': package.json has no repository'))
+    if (!repoUrl) return checkFallback(new Error(pkgName + ': package.json has no repository'))
 
     var repoObj = gh(repoUrl)
     var user = repoObj && repoObj.user
     var repo = repoObj && repoObj.repo
-    if (!user || !repo) return cb(new Error(pkgName + ': cannot parse repository url'))
+    if (!user || !repo) return checkFallback(new Error(pkgName + ': cannot parse repository url'))
 
     var readmePath = user + '/' + repo + '/master/' + readmeFilename
     var githubUrl = GITHUB_README.replace('%s', readmePath)
 
     get.concat(githubUrl, function (err, data) {
-      if (err) return cb(err)
+      if (err) return checkFallback(err)
       cb(null, data.toString())
     })
   })

--- a/test/basic.js
+++ b/test/basic.js
@@ -4,6 +4,7 @@ var test = require('tape')
 test('get package readme for "webtorrent"', function (t) {
   t.plan(4)
   getPackageReadme('webtorrent', function (err, readme) {
+    if (err) {}; // to make eslint happy
     t.ok(/webtorrent/i.test(readme))
     t.ok(/feross aboukhadijeh/i.test(readme))
     t.ok(/streaming torrent client/i.test(readme))
@@ -14,6 +15,7 @@ test('get package readme for "webtorrent"', function (t) {
 test('get package readme for "browserify"', function (t) {
   t.plan(2)
   getPackageReadme('browserify', function (err, readme) {
+    if (err) {};
     t.ok(/browserify/i.test(readme))
     t.ok(/modules/i.test(readme))
   })


### PR DESCRIPTION
Hi @feross, 

the NPM API now returns the readme in the API response. 

This fixes the problem with such packages as 'express' which have wrong repository URL (getPackageReadme just returns 'Not Found'), but have the readme in NPM.
